### PR TITLE
Make platform errors less cryptic

### DIFF
--- a/pkg/platformutil/platformutil.go
+++ b/pkg/platformutil/platformutil.go
@@ -1,0 +1,16 @@
+package platformutil
+
+import (
+	"fmt"
+
+	"github.com/containerd/containerd/platforms"
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+)
+
+func FormatSlice(ps []ocispec.Platform) string {
+	ss := make([]string, len(ps))
+	for i := range ps {
+		ss[i] = platforms.Format(ps[i])
+	}
+	return fmt.Sprintf("%v", ss)
+}


### PR DESCRIPTION
Fix #36

New output:
```console
$ diffoci diff alpine:3.18.2 alpine:3.18.3
INFO[0000] Target platforms: [darwin/amd64]
INFO[0000] Pulling "docker.io/library/alpine:3.18.2" for additional platforms ([darwin/amd64])
docker.io/library/alpine:3.18.2                 saved
└──index (82d1e9d7ed48)                         already exists
Pulling from OCI Registry (docker.io/library/alpine:3.18.2)     elapsed: 2.0 s  total:  1.6 Ki  (839.0 B/s)
INFO[0002] Pulling "docker.io/library/alpine:3.18.3" for additional platforms ([darwin/amd64])
docker.io/library/alpine:3.18.3                 saved
└──index (7144f7bab3d4)                         already exists
Pulling from OCI Registry (docker.io/library/alpine:3.18.3)     elapsed: 0.9 s  total:  1.6 Ki  (1.7 KiB/s)
ERRO[0002] image 0 is not available for the requested platform: unavailable (Hint: specify `--platform` explicitly, e.g., `--platform=linux/amd64`)
```