### PR TITLE
Follow-up to "release.yaml: migrate from `hub` to `gh`"

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -58,4 +58,4 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           tag="${GITHUB_REF##*/}"
-          hub release create -F /tmp/release-note.txt --draft --title "${tag}" "${tag}" _artifacts/*
+          gh release create -F /tmp/release-note.txt --draft --title "${tag}" "${tag}" _artifacts/*


### PR DESCRIPTION
Follow-up to PR 20