### PR TITLE
feat: implement treat-canonical-paths-equal flag

### DIFF
--- a/cmd/diffoci/commands/diff/diff.go
+++ b/cmd/diffoci/commands/diff/diff.go
@@ -44,6 +44,7 @@ func NewCommand() *cobra.Command {
 					"ignore-file-order",
 					"ignore-file-mode-redundant-bits",
 					"ignore-image-name",
+					"treat-canonical-paths-equal",
 				}
 				for _, f := range flagNames {
 					if err := flags.Set(f, "true"); err != nil {
@@ -66,7 +67,8 @@ func NewCommand() *cobra.Command {
 	flags.Bool("ignore-file-order", false, "Ignore file order in tar layers")
 	flags.Bool("ignore-file-mode-redundant-bits", false, "Ignore redundant bits of file mode")
 	flags.Bool("ignore-image-name", false, "Ignore image name annotation")
-	flags.Bool("semantic", false, "[Recommended] Alias for --ignore-*=true")
+	flags.Bool("treat-canonical-paths-equal", false, "Treat leading `./` `/` `` in file paths as canonical")
+	flags.Bool("semantic", false, "[Recommended] Alias for --ignore-*=true --treat-canonical-paths-equal")
 
 	flags.Bool("verbose", false, "Verbose output")
 	flags.String("report-file", "", "Create a report file to the specified path (EXPERIMENTAL)")
@@ -103,6 +105,10 @@ func action(cmd *cobra.Command, args []string) error {
 		return err
 	}
 	options.IgnoreFileModeRedundantBits, err = flags.GetBool("ignore-file-mode-redundant-bits")
+	if err != nil {
+		return err
+	}
+	options.CanonicalPaths, err = flags.GetBool("treat-canonical-paths-equal")
 	if err != nil {
 		return err
 	}

--- a/pkg/diff/diff.go
+++ b/pkg/diff/diff.go
@@ -36,6 +36,7 @@ type IgnoranceOptions struct {
 	IgnoreFileOrder             bool
 	IgnoreFileModeRedundantBits bool
 	IgnoreImageName             bool
+	CanonicalPaths              bool
 }
 
 type Options struct {
@@ -686,6 +687,10 @@ func (d *differ) loadLayer(ctx context.Context, node *EventTreeNode, inputIdx in
 		hdr, err := tr.Next()
 		if errors.Is(err, io.EOF) {
 			break
+		}
+		if d.o.CanonicalPaths {
+			hdr.Name = strings.TrimPrefix(hdr.Name, "/")
+			hdr.Name = strings.TrimPrefix(hdr.Name, "./")
 		}
 		res.entries++
 		ent := &TarEntry{


### PR DESCRIPTION
When tars extracted, essentially `` (no prefix) , `/` (leading slash),  `./` (dot slash) all mean the same thing, relative to `chroot` of the container. 

This flag implements a feature where these paths are considered the same.  

I didn't add any tests, as i didn't know where to put them. 