### PR TITLE
distinguish file & image timestamps

### DIFF
--- a/cmd/diffoci/commands/diff/diff.go
+++ b/cmd/diffoci/commands/diff/diff.go
@@ -39,13 +39,25 @@ func NewCommand() *cobra.Command {
 			flags := cmd.Flags()
 			if semantic, _ := cmd.Flags().GetBool("semantic"); semantic {
 				flagNames := []string{
-					"ignore-timestamps",
 					"ignore-history",
 					"ignore-file-order",
 					"ignore-file-mode-redundant-bits",
+					"ignore-file-timestamps",
+					"ignore-image-timestamps",
 					"ignore-image-name",
 					"ignore-tar-format",
 					"treat-canonical-paths-equal",
+				}
+				for _, f := range flagNames {
+					if err := flags.Set(f, "true"); err != nil {
+						return err
+					}
+				}
+			}
+			if ignoreTimestamps, _ := cmd.Flags().GetBool("ignore-timestamps"); ignoreTimestamps {
+				flagNames := []string{
+					"ignore-file-timestamps",
+					"ignore-image-timestamps",
 				}
 				for _, f := range flagNames {
 					if err := flags.Set(f, "true"); err != nil {
@@ -62,11 +74,12 @@ func NewCommand() *cobra.Command {
 
 	flags := cmd.Flags()
 	flagutil.AddPlatformFlags(flags)
-
-	flags.Bool("ignore-timestamps", false, "Ignore timestamps")
+	flags.Bool("ignore-timestamps", false, "Ignore timestamps - Alias for --ignore-*-timestamps=true")
 	flags.Bool("ignore-history", false, "Ignore history")
 	flags.Bool("ignore-file-order", false, "Ignore file order in tar layers")
 	flags.Bool("ignore-file-mode-redundant-bits", false, "Ignore redundant bits of file mode")
+	flags.Bool("ignore-file-timestamps", false, "Ignore timestamps on files")
+	flags.Bool("ignore-image-timestamps", false, "Ignore timestamps in image metadata")
 	flags.Bool("ignore-image-name", false, "Ignore image name annotation")
 	flags.Bool("ignore-tar-format", false, "Ignore tar format")
 	flags.Bool("treat-canonical-paths-equal", false, "Treat leading `./` `/` `` in file paths as canonical")
@@ -95,10 +108,6 @@ func action(cmd *cobra.Command, args []string) error {
 	platMC := platforms.Any(plats...)
 
 	var options diff.Options
-	options.IgnoreTimestamps, err = flags.GetBool("ignore-timestamps")
-	if err != nil {
-		return err
-	}
 	options.IgnoreHistory, err = flags.GetBool("ignore-history")
 	if err != nil {
 		return err
@@ -108,6 +117,14 @@ func action(cmd *cobra.Command, args []string) error {
 		return err
 	}
 	options.IgnoreFileModeRedundantBits, err = flags.GetBool("ignore-file-mode-redundant-bits")
+	if err != nil {
+		return err
+	}
+	options.IgnoreFileTimestamps, err = flags.GetBool("ignore-file-timestamps")
+	if err != nil {
+		return err
+	}
+	options.IgnoreImageTimestamps, err = flags.GetBool("ignore-image-timestamps")
 	if err != nil {
 		return err
 	}

--- a/pkg/diff/diff.go
+++ b/pkg/diff/diff.go
@@ -32,10 +32,11 @@ import (
 )
 
 type IgnoranceOptions struct {
-	IgnoreTimestamps            bool
 	IgnoreHistory               bool
 	IgnoreFileOrder             bool
 	IgnoreFileModeRedundantBits bool
+	IgnoreFileTimestamps        bool
+	IgnoreImageTimestamps       bool
 	IgnoreImageName             bool
 	IgnoreTarFormat             bool
 	CanonicalPaths              bool
@@ -374,7 +375,7 @@ func (d *differ) diffDescriptorSliceField(ctx context.Context, node *EventTreeNo
 
 func (d *differ) diffAnnotationsField(ctx context.Context, node *EventTreeNode, in [2]EventInput, evType EventType, maps [2]map[string]string, fieldName string) error {
 	negligible := map[string]struct{}{}
-	if d.o.IgnoreTimestamps {
+	if d.o.IgnoreImageTimestamps {
 		negligible[ocispec.AnnotationCreated] = struct{}{}
 	}
 	if d.o.IgnoreImageName {
@@ -555,7 +556,7 @@ func (d *differ) diffConfig(ctx context.Context, node *EventTreeNode, in [2]Even
 	if d.o.digestMayChange() {
 		negligibleFields = append(negligibleFields, "RootFS")
 	}
-	if d.o.IgnoreTimestamps {
+	if d.o.IgnoreImageTimestamps {
 		// history contains timestamps
 		negligibleFields = append(negligibleFields, "Created", "History")
 	}
@@ -603,7 +604,7 @@ func (d *differ) diffConfig(ctx context.Context, node *EventTreeNode, in [2]Even
 			}
 		} else {
 			var negligibleHistoryFields []string
-			if d.o.IgnoreTimestamps {
+			if d.o.IgnoreImageTimestamps {
 				negligibleHistoryFields = append(negligibleHistoryFields, "Created")
 			}
 			for i := range in[0].Config.History {
@@ -865,7 +866,7 @@ func (d *differ) diffTarEntries(ctx context.Context, node *EventTreeNode, in [2]
 
 func (d *differ) diffTarEntry(ctx context.Context, node *EventTreeNode, in [2]EventInput) (dirsToBeRemovedIfEmpty []string, retErr error) {
 	var negligibleTarFields []string
-	if d.o.IgnoreTimestamps {
+	if d.o.IgnoreFileTimestamps {
 		negligibleTarFields = append(negligibleTarFields, "ModTime", "AccessTime", "ChangeTime")
 	}
 	cmpOpts := []cmp.Option{cmpopts.IgnoreUnexported(TarEntry{}), cmpopts.IgnoreFields(tar.Header{}, negligibleTarFields...)}


### PR DESCRIPTION
See https://github.com/reproducible-containers/diffoci/pull/192

I need to distinguish the timestamps on the files and the timestamps on the image metadata. If I rebuild from cache, the timestamps on the files must be identical, the timestamps on the image are new. Hence I introduced `--ignore-file-timestamps` and `ignore-image-timestamps` respectively, `--ignore-timestamps` is now an alias for the two new options.