### PR TITLE
normalize link paths

### DIFF
--- a/pkg/diff/diff.go
+++ b/pkg/diff/diff.go
@@ -700,6 +700,8 @@ func (d *differ) loadLayer(ctx context.Context, node *EventTreeNode, inputIdx in
 		if d.o.CanonicalPaths {
 			hdr.Name = strings.TrimPrefix(hdr.Name, "/")
 			hdr.Name = strings.TrimPrefix(hdr.Name, "./")
+			hdr.Linkname = strings.TrimPrefix(hdr.Linkname, "/")
+			hdr.Linkname = strings.TrimPrefix(hdr.Linkname, "./")
 		}
 		if os.Geteuid() != 0 && runtime.GOOS == "linux" {
 			//nolint:staticcheck // SA1019: hdr.Xattrs has been deprecated since Go 1.10: Use PAXRecords instead.


### PR DESCRIPTION
See https://github.com/reproducible-containers/diffoci/pull/192

When we pass `--treat-canonical-paths-equal` we should not only normalize file-paths, but also the paths links point to.