### PR TITLE
fix: pass --platform to docker save to prevent blob not found errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,8 +51,9 @@ diffoci diff IMAGE0 IMAGE1
 ```
 
 > [!TIP]
-> Non-Linux users typically have to specify `--platform` explicitly.
+> Non-Linux users and those comparing multi-platform images from Docker typically have to specify `--platform` explicitly.
 > e.g., `diffoci diff --platform=linux/amd64 IMAGE0 IMAGE1`.
+> (Note: Platform filtering for `docker://` images requires Docker v28+)
 
 The strict mode is often too strict.
 Consider using the non-strict mode (see below).


### PR DESCRIPTION
to reproduce:
```bash
# Pull a multi-platform image
~$ docker pull golang:1.25-alpine3.22
1.25-alpine3.22: Pulling from library/golang
Digest: sha256:3587db7cc96576822c606d119729370dbf581931c5f43ac6d3fa03ab4ed85a10
Status: Image is up to date for golang:1.25-alpine3.22
docker.io/library/golang:1.25-alpine3.22
# Pull another multi-platform image
~$ docker pull golang:1.24-alpine3.22
1.24-alpine3.22: Pulling from library/golang
Digest: sha256:fb828ef85a4c4140fae45f145a84ca9c0a83fd0baa437a301b35b551e91ceed5
Status: Image is up to date for golang:1.24-alpine3.22
docker.io/library/golang:1.24-alpine3.22
~$ diffoci diff docker://golang:1.25-alpine3.22 docker://golang:1.24-alpine3.22
INFO[0000] Target platforms: [linux/amd64]              
INFO[0000] Loading image "docker.io/library/golang:1.25-alpine3.22" from "docker" 
FATA[0001] failed to load an archive (from [docker save docker.io/library/golang:1.25-alpine3.22]): failed to load: blob sha256:f8629c643ffe4b76e09be0b3609b48d45a8527732d6acadbc8e532bf77f3e537 expected at /home/devsog12/.cache/diffoci/blobs/sha256/f8629c643ffe4b76e09be0b3609b48d45a8527732d6acadbc8e532bf77f3e537: blob not found: not found 
```

when docker save exports a multi-platform image, the manifest list references platforms that may not have been pulled locally. This causes containerd's import to fail with `blob not found` errors.

to fix this, we can pass the --platform flag to docker save to export only the requested platform(s), matching the blobs that actually exist locally