### PR TITLE
docs: fix --containerd-socket -> --containerd-address in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ The default namespace is `default`.
 
 To explicitly enable containerd:
 ```bash
-diffoci --backend=containerd --containerd-socket=SOCKET --containerd-namespace=NAMESPACE
+diffoci --backend=containerd --containerd-address=ADDRESS --containerd-namespace=NAMESPACE
 ```
 
 To explicitly disable containerd:


### PR DESCRIPTION
Fixes #265.

## Problem

README.md:100 documents the containerd backend as:

~~~bash
diffoci --backend=containerd --containerd-socket=SOCKET --containerd-namespace=NAMESPACE
~~~

But `--containerd-socket` is not a real flag. The containerd backend registers `--containerd-address` at `cmd/diffoci/backend/containerdbackend/containerdbackend.go:26`:

~~~go
flags.String("containerd-address", envutil.String("CONTAINERD_ADDRESS", defaultContainerdAddress()), ...)
~~~

Running the documented command produces:

~~~
level=fatal msg="unknown flag: --containerd-socket"
~~~

## Fix

Update the README example to use the real flag name (`--containerd-address`) and a value placeholder (`ADDRESS`) that matches the `CONTAINERD_ADDRESS` env var the code reads.