### PR TITLE
docs(readme): correct containerd backend flag to --containerd-address

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ The default namespace is `default`.
 
 To explicitly enable containerd:
 ```bash
-diffoci --backend=containerd --containerd-socket=SOCKET --containerd-namespace=NAMESPACE
+diffoci --backend=containerd --containerd-address=ADDRESS --containerd-namespace=NAMESPACE
 ```
 
 To explicitly disable containerd:


### PR DESCRIPTION
Fixes #265

## Summary

The "explicit enable containerd" example in `README.md` referenced `--containerd-socket`, which the binary rejects:

```
time="..." level=fatal msg="unknown flag: --containerd-socket"
```

Looking at `cmd/diffoci/backend/containerdbackend/containerdbackend.go`, the flag registered on the containerd backend is `--containerd-address` (bound to `CONTAINERD_ADDRESS`). `--containerd-socket` does not exist.

## Change

`README.md`: update the example to use `--containerd-address=ADDRESS`, matching the actual flag name. `--containerd-namespace` was already correct.

## Testing

Grepped the full tree (`grep -rn "containerd-socket\|containerd-address"`) - the only remaining `containerd-socket` reference was in this README line; the flag registration, getter, and every other mention uses `containerd-address`.

DCO signoff included.
