### PR TITLE
ci: update GitHub Actions; migrate to golangci-lint v2

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,13 +9,13 @@ jobs:
   main:
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-go@v6
+      - uses: actions/checkout@v7
+      - uses: actions/setup-go@v7
         with:
           go-version: "oldstable"
       - run: go test -covermode=atomic -race -v ./...
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v6.5.2
+        uses: golangci/golangci-lint-action@v9.3.0
         with:
           args: --verbose
       - run: go install ./cmd/diffoci

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-24.04
     timeout-minutes: 20
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
         with:
           # https://github.com/reproducible-containers/repro-get/issues/3
           fetch-depth: 0

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,21 @@
+version: "2"
+linters:
+  settings:
+    staticcheck:
+      # Keep the golangci-lint default checks, minus QF* (quickfix):
+      # those are refactoring suggestions, not correctness issues, and are
+      # disabled in staticcheck's own default configuration too.
+      checks:
+        - all
+        - -ST1000
+        - -ST1003
+        - -ST1016
+        - -ST1020
+        - -ST1021
+        - -ST1022
+        - -QF*
+  exclusions:
+    presets:
+      # Restore the golangci-lint v1 default exclusions for unchecked errors
+      # of functions like fmt.Fprintln.
+      - std-error-handling

--- a/cmd/diffoci/imagegetter/imagegetter.go
+++ b/cmd/diffoci/imagegetter/imagegetter.go
@@ -15,7 +15,6 @@ import (
 	"github.com/containerd/containerd/images"
 	"github.com/containerd/containerd/pkg/transfer"
 	"github.com/containerd/containerd/pkg/transfer/archive"
-	"github.com/containerd/containerd/pkg/transfer/image"
 	transimage "github.com/containerd/containerd/pkg/transfer/image"
 	"github.com/containerd/containerd/pkg/transfer/registry"
 	"github.com/containerd/errdefs"
@@ -44,9 +43,8 @@ func Load(ctx context.Context, stdout io.Writer, transferrer transfer.Transferre
 
 	sOpts := []transimage.StoreOpt{
 		transimage.WithPlatforms(plats...),
-		image.WithPlatforms(plats...),
-		image.WithAllMetadata,
-		image.WithNamedPrefix("unused", true),
+		transimage.WithAllMetadata,
+		transimage.WithNamedPrefix("unused", true),
 	}
 	is := transimage.NewStore(foreknownRef, sOpts...)
 


### PR DESCRIPTION
- actions/checkout v6 -> v7
- actions/setup-go v6 -> v7
- golangci/golangci-lint-action v6.5.2 -> v9.3.0

The golangci-lint-action bump switches from golangci-lint v1 to v2, which drops the v1 default exclusions. Add .golangci.yml to restore the std-error-handling exclusion preset and disable the stylistic QF* (quickfix) staticcheck checks, which staticcheck itself keeps off by default.

Also fix the one genuine new lint finding (ST1019): the transfer/image package was imported twice in imagegetter.go, with WithPlatforms consequently applied twice through the two aliases.